### PR TITLE
Make yt-dlp a required dependency and keep it fresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Claude Desktop / Claude Code などから、動画の要約、翻訳、ノート
 - 手動字幕を優先し、なければ自動生成字幕にフォールバック
 - 字幕言語は `ja` / `en` / `ko` を優先（自動選択）、タイムスタンプ付与は任意指定
 - Markdown 形式で字幕を出力
-- `yt-dlp` が使える場合はタイトル、投稿者、投稿日なども取得
+- タイトル、投稿者、投稿日などのメタデータも取得
 - ローカルキャッシュに対応（stdio 接続）
 
 ## 提供ツール
@@ -33,14 +33,17 @@ Claude Desktop / Claude Code などから、動画の要約、翻訳、ノート
 
 ```bash
 cd yt-transcript-mcp
-uv sync --extra ytdlp
-```
-
-`yt-dlp` はメタデータ取得用です。字幕だけ取得できればよい場合は、次の最小構成でも動きます。
-
-```bash
 uv sync
 ```
+
+これだけで `yt-dlp` を含む依存が揃います。システムに `yt-dlp` を別途インストールする必要はありません（`uv run` 配下では venv 内の `yt-dlp` が PATH 上のものより優先されます）。
+
+> [!IMPORTANT]
+> `yt-dlp` は YouTube 側の仕様変更に追従し続けることで動いているツールです。`uv.lock` に固定したまま放置するといずれメタデータ取得が壊れます。壊れたら（あるいは定期的に）次を実行してください。
+>
+> ```bash
+> uv run poe update-ytdlp
+> ```
 
 ## クライアント設定
 
@@ -162,9 +165,9 @@ CACHE_DIR=/tmp/yt-transcript-cache uv run python server.py
 
 ### メタデータが `Unknown` になる
 
-- `yt-dlp` がインストールされていない可能性があります
-- `uv sync --extra ytdlp` を実行してください
 - `youtube_get_video_info` の JSON に `metadata_error` がある場合は、`type` と `stderr` を確認してください
+- `type` が `yt_dlp_not_found` なら依存が入っていません。`uv sync` を実行してください
+- それ以外（`yt_dlp_failed` など）で `stderr` が YouTube の仕様変更を示している場合は、`yt-dlp` が古い可能性があります。`uv run poe update-ytdlp` で更新してください
 - YouTube 側の制限や一時的な取得失敗でも `Unknown` になることがあります
 
 ### 出力が長すぎる
@@ -175,7 +178,7 @@ CACHE_DIR=/tmp/yt-transcript-cache uv run python server.py
 ## 開発
 
 ```bash
-uv sync --extra ytdlp --dev
+uv sync --dev
 uv run python -m unittest discover -s tests
 uv run poe check
 ```
@@ -187,6 +190,17 @@ uv run poe check
 | `uv run poe lint` | Ruff の lint を `--fix` 付きで実行 |
 | `uv run poe type-check` | mypy を実行 |
 | `uv run poe check` | format / lint / type-check をまとめて実行 |
+| `uv run poe update-ytdlp` | `yt-dlp` を最新に更新して lock を書き換える |
+
+### 依存の方針
+
+**すべて uv に一本化し、システムへの別途インストールを前提にしない。** 他者の環境へ移したときに「私の環境では動く」を起こさないための方針です。
+
+- **`youtube-transcript-api`** — 純粋な Python 依存。`uv.lock` で固定。
+- **`yt-dlp`** — 必須依存。システム版（brew など）があってもそちらは使いません。ただし YouTube の変更に追従し続けることで動くツールなので、**固定しっぱなしにしないこと**が重要です（`poe update-ytdlp`）。ここだけは「固定＝安全」が成り立ちません。
+- **`ffmpeg`** — 現時点で未使用。#9（フレーム取得）で必要になったら [`imageio-ffmpeg`](https://pypi.org/project/imageio-ffmpeg/) を依存に追加します。静的バイナリを同梱しており、brew / nix なしで uv 管理下に置けることを確認済みです。ffmpeg 単体のみで `ffprobe` は付かない点に注意。
+
+Nix flake は現状不要です（#10）。依存のうち 2 つは既に uv が再現性を担保しており、1 つは未使用のため、導入しても実質何も解決しません。加えて Nix の本質であるシステム依存の凍結は、上記のとおり `yt-dlp` とは相性が悪く逆効果です。
 
 ### ツール description は短く保つ
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,11 @@ dependencies = [
     "mcp[cli]>=1.0.0",
     "youtube-transcript-api>=1.0.0",
     "pydantic>=2.0.0",
+    # Required, not optional: metadata is fetched on every transcript call.
+    # yt-dlp breaks as YouTube changes, so refresh it with `uv run poe update-ytdlp`
+    # rather than letting uv.lock pin an old version indefinitely.
+    "yt-dlp>=2024.0.0",
 ]
-
-[project.optional-dependencies]
-ytdlp = ["yt-dlp>=2024.0.0"]
 
 [build-system]
 requires = ["hatchling"]
@@ -46,3 +47,7 @@ check    = ["format", "lint", "type-check"]
 # hook用に分離
 check-fast = ["format", "lint"]   # PostToolUse から呼ぶ
 check-type = ["type-check"]       # Stop から呼ぶ
+
+# yt-dlp は YouTube の変更に追従し続けるから動く。lock に固定したまま放置すると
+# いずれ動画取得が壊れるので、定期的に叩いて lock を更新する
+update-ytdlp = { shell = "uv lock --upgrade-package yt-dlp && uv sync" }

--- a/uv.lock
+++ b/uv.lock
@@ -1371,10 +1371,6 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
     { name = "youtube-transcript-api" },
-]
-
-[package.optional-dependencies]
-ytdlp = [
     { name = "yt-dlp" },
 ]
 
@@ -1391,9 +1387,8 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "youtube-transcript-api", specifier = ">=1.0.0" },
-    { name = "yt-dlp", marker = "extra == 'ytdlp'", specifier = ">=2024.0.0" },
+    { name = "yt-dlp", specifier = ">=2024.0.0" },
 ]
-provides-extras = ["ytdlp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1405,9 +1400,9 @@ dev = [
 
 [[package]]
 name = "yt-dlp"
-version = "2026.2.21"
+version = "2026.7.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/d9/55ffff25204733e94a507552ad984d5a8a8e4f9d1f0d91763e6b1a41c79b/yt_dlp-2026.2.21.tar.gz", hash = "sha256:4407dfc1a71fec0dee5ef916a8d4b66057812939b509ae45451fa8fb4376b539", size = 3116630, upload-time = "2026-02-21T20:40:53.522Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c5/9972af4b472b0d55badf841ebafd2f98944cb0ae0f46e11d01f363ea5b91/yt_dlp-2026.7.4.tar.gz", hash = "sha256:b094813404f87a9dd2186f00815231df32e5fd8a5403be0f807b3bb2d21a4432", size = 3049326, upload-time = "2026-07-04T22:42:14.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/40/664c99ee36d80d84ce7a96cd98aebcb3d16c19e6c3ad3461d2cf5424040e/yt_dlp-2026.2.21-py3-none-any.whl", hash = "sha256:0d8408f5b6d20487f5caeb946dfd04f9bcd2f1a3a125b744a0a982b590e449f7", size = 3313392, upload-time = "2026-02-21T20:40:51.514Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8a/cd4c9b02c10c563adfe78118310129641900e1cd6de888cfae2452072696/yt_dlp-2026.7.4-py3-none-any.whl", hash = "sha256:f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266", size = 3184705, upload-time = "2026-07-04T22:42:12.989Z" },
 ]


### PR DESCRIPTION
#10（Nix を使った依存管理）への回答と、その過程で見つかった移植性のバグの修正です。

> [!NOTE]
> PR #11 の上に積んでいます（README / pyproject を共通で触るため）。ベースは #11 マージ後に自動で main へ付け替わります。

## 結論: Nix は現状不要

挙がっていた 3 つの依存を実測したところ、前提が成立していませんでした。

| 依存 | 実態 |
| --- | --- |
| `youtube-transcript-api` | 純粋な Python 依存。システム依存ではなく、最初から `uv.lock` で固定済み |
| `yt-dlp` | 既に uv 管理下（`uv run` 配下では venv 版が brew 版より優先されることを実測で確認） |
| `ffmpeg` | **コード内に言及ゼロ。現時点で未使用**（#9 で必要になる） |

2 つは既に uv が再現性を担保しており、1 つは使われていないため、Nix を入れても実質何も解決しません。

さらに **Nix の本質であるシステム依存の凍結は、`yt-dlp` に対しては逆効果**です。yt-dlp は YouTube の変更に追従し続けることで動いており、凍結は将来の破損を保証します。#10 が目指す再現性と、yt-dlp の現実は正面から衝突します。

## 実際に見つかったバグ: yt-dlp が optional だった

「他者の環境へ移した際の不具合」を潰すレバーは Nix ではなくこれでした。

メタデータは毎回取得する作りなので、yt-dlp は実質必須なのに optional 宣言でした。素の `uv sync` をした人はメタデータが黙って `Unknown` に劣化し、一方このマシンでは brew の yt-dlp が PATH にいたため動いていました。典型的な「私の環境では動く」です。

`dependencies` へ移し、extra を廃止しました。クリーンなチェックアウトで素の `uv sync` のみで動作することを確認済みです。

## 陳腐化への対処

`uv.lock` の yt-dlp は **2026.02.21** まで腐っており、brew 版（2026.7.4）より 5 ヶ月古い状態でした。今日時点では両方とも動きましたが、放置すれば必ず壊れます。

- `poe update-ytdlp` を追加（`uv lock --upgrade-package yt-dlp && uv sync`）
- lock を 2026.7.4 へ更新
- README に「固定しっぱなしにしない」理由と手順を明記
- トラブルシューティングを `metadata_error` の `type` で分岐するよう修正（未インストールか、yt-dlp が古いか）

## ffmpeg の方針（記録のみ、実装なし）

#9 で必要になった際は [`imageio-ffmpeg`](https://pypi.org/project/imageio-ffmpeg/) 経由で uv 管理下に置けます。静的バイナリ（v7.1）を同梱しており brew / nix なしで動作することを実測で確認しました。`ffprobe` は付属しない点のみ注意。**未使用のものを今 required にはしていません。**

つまり #9 が入っても Nix の出番はありません。

## 検証

- クリーンな checkout + 素の `uv sync --frozen` → `yt-dlp 2026.7.4` が入ることを確認
- `uv run python -m unittest discover -s tests` — 23 件パス
- `uv run poe check` — クリーン
- 新旧両方の yt-dlp で実際に YouTube からメタデータ取得が成功することを確認

Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)