### PR TITLE
Add youtube_get_frame for slides, code, and charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Claude Desktop / Claude Code などから、動画の要約、翻訳、ノート
 | --- | --- |
 | `youtube_get_transcript` | 字幕を取得し、Markdown 形式で返す |
 | `youtube_get_video_info` | 字幕を取得せず、動画メタデータだけを JSON で返す |
+| `youtube_get_frame` | 指定時刻のフレームを 1 枚、画像で返す |
 
 ## セットアップ
 
@@ -122,6 +123,26 @@ MCP クライアントで YouTube URL を含む依頼をします。
 > [!NOTE]
 > 長尺動画の任意区間や続きを取得する必要が出た場合は、区間指定の専用ツール（例: `youtube_get_transcript_segment(url, start_seconds)`）の追加を検討します。現時点では未実装です。
 
+### `youtube_get_frame`
+
+字幕だけでは分からない場面（スライド、画面上のコード、図表、字幕なしのデモ）で使います。
+
+| パラメータ | デフォルト | 説明 |
+| --- | --- | --- |
+| `url` | 必須 | YouTube URL または 11 文字の動画 ID |
+| `timestamp` | 必須 | 秒（`90`）、`MM:SS`（`01:30`）、`HH:MM:SS`（`00:01:30`） |
+
+`youtube_get_transcript` に `include_timestamps=true` を渡すと各行に `[MM:SS]` が付くので、
+その値をそのまま `timestamp` に渡せます。
+
+動画はダウンロードしません。`yt-dlp` でストリーム URL を解決し、`ffmpeg` が HTTP range で
+必要な範囲だけ読んで 1 フレームを JPEG で返します。116 分の動画の任意の地点でも数秒、
+ディスクには何も残りません。解像度は 720p 上限です（360p では画面上のコードが判読できず、
+720p なら本用途には十分なため）。
+
+> [!NOTE]
+> 画像はクライアント UI 上では折りたたまれて表示されますが、モデルには渡っています。
+
 ### `youtube_get_video_info`
 
 動画の概要だけ確認したい場合に使います。
@@ -198,7 +219,7 @@ uv run poe check
 
 - **`youtube-transcript-api`** — 純粋な Python 依存。`uv.lock` で固定。
 - **`yt-dlp`** — 必須依存。システム版（brew など）があってもそちらは使いません。ただし YouTube の変更に追従し続けることで動くツールなので、**固定しっぱなしにしないこと**が重要です（`poe update-ytdlp`）。ここだけは「固定＝安全」が成り立ちません。
-- **`ffmpeg`** — 現時点で未使用。#9（フレーム取得）で必要になったら [`imageio-ffmpeg`](https://pypi.org/project/imageio-ffmpeg/) を依存に追加します。静的バイナリを同梱しており、brew / nix なしで uv 管理下に置けることを確認済みです。ffmpeg 単体のみで `ffprobe` は付かない点に注意。
+- **`imageio-ffmpeg`** — `youtube_get_frame` のフレーム抽出に使用。静的バイナリを同梱しており、brew / nix なしで uv 管理下に置けます。ffmpeg 単体のみで `ffprobe` は付きませんが、フレーム抽出は ffmpeg だけで完結するため問題ありません。
 
 Nix flake は現状不要です（#10）。依存のうち 2 つは既に uv が再現性を担保しており、1 つは未使用のため、導入しても実質何も解決しません。加えて Nix の本質であるシステム依存の凍結は、上記のとおり `yt-dlp` とは相性が悪く逆効果です。
 
@@ -213,4 +234,3 @@ MCP クライアントはツール発見時に `description` と引数スキー�
 - [ ] 字幕がない動画向けの Whisper 連携
 - [ ] プレイリスト URL の一括処理
 - [ ] キャッシュの明示的な削除・更新オプション
-- [ ] スライドや表などを扱うためのフレーム取得

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     # yt-dlp breaks as YouTube changes, so refresh it with `uv run poe update-ytdlp`
     # rather than letting uv.lock pin an old version indefinitely.
     "yt-dlp>=2024.0.0",
+    # Ships a static ffmpeg binary, so frame extraction needs no brew/nix install.
+    "imageio-ffmpeg>=0.5.0",
 ]
 
 [build-system]

--- a/server.py
+++ b/server.py
@@ -9,13 +9,26 @@ from datetime import date
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP, Image
 from mcp.types import ToolAnnotations
 
 DEFAULT_LANGUAGES = ["ja", "en", "ko"]
 MAX_TRANSCRIPT_CHARS = 200_000  # safety limit to avoid blowing up context
 CACHE_TTL_DAYS = 180
 VIDEO_ID_RE = re.compile(r"[a-zA-Z0-9_-]{11}")
+
+# Seconds ("1234"), or MM:SS / HH:MM:SS, with optional fractional part.
+TIMESTAMP_RE = re.compile(r"\d+(:\d{1,2}){0,2}(\.\d+)?")
+# Video-only: frames need no audio, and it is smaller than 360p+audio.
+# Capped at 720p, which resolves on-screen code where 360p does not.
+# avc1 first: it decodes ~25% faster than the av01 of the same resolution.
+# protocol^=http on every tier keeps yt-dlp off HLS, whose m3u8 manifest
+# ffmpeg cannot open here. Each tier has been checked to decode.
+FRAME_FORMAT = (
+    "bv*[height<=720][vcodec^=avc1][protocol^=http]"
+    "/bv*[height<=720][protocol^=http]"
+    "/b[height<=720][protocol^=http]"
+)
 
 mcp = FastMCP("yt-transcript-mcp")
 
@@ -431,6 +444,77 @@ def _save_cache(video_id: str, languages: list[str], transcript_info: dict) -> N
         pass
 
 
+# ── Frame extraction ──────────────────────────────────────────────────────────
+
+
+def _stream_url(video_id: str) -> str:
+    """Resolve a direct video stream URL via yt-dlp.
+
+    The URL carries an `expire` param (hours), so it cannot be cached.
+    """
+    result = subprocess.run(
+        [
+            "yt-dlp",
+            "-f",
+            FRAME_FORMAT,
+            "-g",
+            "--no-warnings",
+            f"https://www.youtube.com/watch?v={video_id}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"yt-dlp could not resolve a stream URL: {result.stderr[-500:]}"
+        )
+
+    url = result.stdout.strip().splitlines()
+    if not url:
+        raise RuntimeError("yt-dlp returned no stream URL.")
+    return url[0]
+
+
+def _extract_frame(stream_url: str, timestamp: str) -> bytes:
+    """Grab one JPEG frame at timestamp. ffmpeg range-reads only what it needs."""
+    import imageio_ffmpeg  # type: ignore[import-untyped]
+
+    result = subprocess.run(
+        [
+            imageio_ffmpeg.get_ffmpeg_exe(),
+            "-nostdin",
+            "-loglevel",
+            "error",
+            # -ss before -i seeks on the input, so ffmpeg fetches only the bytes
+            # around the timestamp instead of streaming the whole video.
+            "-ss",
+            timestamp,
+            "-i",
+            stream_url,
+            "-frames:v",
+            "1",
+            "-q:v",
+            "2",
+            "-f",
+            "image2pipe",
+            "-vcodec",
+            "mjpeg",
+            "pipe:1",
+        ],
+        capture_output=True,
+        timeout=120,
+    )
+    if result.returncode != 0 or not result.stdout:
+        # The signed stream URL is ~1000 chars and ffmpeg echoes it back on
+        # failure, so drop it first or it crowds out the actual error.
+        stderr = result.stderr.decode("utf-8", "replace").replace(
+            stream_url, "<stream>"
+        )
+        raise RuntimeError(f"ffmpeg could not extract a frame: {stderr.strip()[-500:]}")
+    return result.stdout
+
+
 # ── MCP tools ─────────────────────────────────────────────────────────────────
 
 
@@ -521,6 +605,55 @@ async def youtube_get_video_info(url: str) -> str:
         return str(e)
     metadata = _get_metadata(video_id, full_description=True)
     return json.dumps(metadata, ensure_ascii=False, indent=2)
+
+
+@mcp.tool(
+    name="youtube_get_frame",
+    # Keep this short: it is copied into the client's context on tool discovery.
+    description=(
+        "Return one video frame at a timestamp as an image. "
+        "timestamp accepts seconds or MM:SS / HH:MM:SS. "
+        "Use when the transcript alone is not enough (slides, code, charts)."
+    ),
+    annotations=ToolAnnotations(
+        title="Get YouTube Frame",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+    # Image has no pydantic schema, so an output schema cannot be built for the
+    # Image | str return that keeps errors as text like the other tools.
+    structured_output=False,
+)
+async def youtube_get_frame(url: str, timestamp: str) -> Image | str:
+    """Return a single JPEG frame from a YouTube video at the given timestamp."""
+    url = url.strip().strip("<>")
+    try:
+        video_id = _extract_video_id(url)
+    except ValueError as e:
+        return str(e)
+
+    timestamp = timestamp.strip()
+    # Validated, not just parsed: an unchecked value starting with "-" would be
+    # read by ffmpeg as an option rather than a timestamp.
+    if not TIMESTAMP_RE.fullmatch(timestamp):
+        return (
+            f"Invalid timestamp: {timestamp!r}. "
+            "Use seconds (90), MM:SS (01:30), or HH:MM:SS (00:01:30)."
+        )
+
+    try:
+        return Image(
+            data=_extract_frame(_stream_url(video_id), timestamp), format="jpeg"
+        )
+    except subprocess.TimeoutExpired:
+        return f"Timed out fetching a frame for video {video_id}."
+    except Exception as e:
+        return (
+            f"Error: Could not extract a frame for video {video_id} "
+            f"at {timestamp}.\n{e}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -436,5 +436,39 @@ class ToolTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(parsed["metadata_error"]["type"], "yt_dlp_failed")
 
 
+class FrameTests(unittest.IsolatedAsyncioTestCase):
+    async def test_accepts_seconds_and_clock_timestamps(self):
+        with (
+            patch.object(server, "_stream_url", return_value="https://example/v.mp4"),
+            patch.object(
+                server, "_extract_frame", return_value=b"jpegbytes"
+            ) as extract,
+        ):
+            for value in ("90", "01:30", "00:01:30", "20:14.5"):
+                with self.subTest(value=value):
+                    result = await server.youtube_get_frame("dQw4w9WgXcQ", value)
+                    self.assertIsInstance(result, server.Image)
+                    self.assertEqual(result.data, b"jpegbytes")
+                    self.assertEqual(extract.call_args.args[1], value)
+
+    async def test_rejects_timestamp_that_ffmpeg_would_read_as_an_option(self):
+        with patch.object(server, "_extract_frame") as extract:
+            result = await server.youtube_get_frame("dQw4w9WgXcQ", "-i")
+
+        self.assertIsInstance(result, str)
+        self.assertIn("Invalid timestamp", result)
+        extract.assert_not_called()
+
+    async def test_reports_extraction_failure_as_text(self):
+        with (
+            patch.object(server, "_stream_url", return_value="https://example/v.mp4"),
+            patch.object(server, "_extract_frame", side_effect=RuntimeError("boom")),
+        ):
+            result = await server.youtube_get_frame("dQw4w9WgXcQ", "90")
+
+        self.assertIsInstance(result, str)
+        self.assertIn("boom", result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -417,6 +417,20 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1368,6 +1382,7 @@ name = "youtube-transcript-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "imageio-ffmpeg" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
     { name = "youtube-transcript-api" },
@@ -1384,6 +1399,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "imageio-ffmpeg", specifier = ">=0.5.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "youtube-transcript-api", specifier = ">=1.0.0" },


### PR DESCRIPTION
Closes #9.

## なぜ必要か

字幕は画面上の情報を構造的に運べません。Karpathy "Let's build GPT" の 20:00 で検証しました。

| | 内容 |
| --- | --- |
| 字幕（自動生成） | `as we saw here` / `torch. stack` / `I INX` |
| 同時刻のフレーム | `x = torch.stack([data[i:i+block_size] for i in ix])` |

「as we saw here」のような指示語は画面がないと意味をなさず、音声認識は発話されないコードを崩します。画面上の出力値（テンソルの中身）に至っては発話すらされません。

一方、トーキングヘッド動画のフレームは情報ゼロでした。**価値はコンテンツ依存**です。だからこそオンデマンドの 1 発ツールが正しく、呼び出し側は字幕で足りない時だけ呼ぶので、1 枚あたり約 1,200 トークンのコストは価値がある時にだけ支払われます。

## どう実装したか

動画はダウンロードしません。yt-dlp でストリーム URL を解決し、ffmpeg が HTTP range でタイムスタンプ周辺のバイトだけを読みます。116 分の動画の任意の地点でも数秒、ディスクには何も残りません。

- **720p 上限**: 360p では画面上のコードが判読できません（実測）
- **avc1 優先**: 同解像度の av01 より復号が約 25% 高速（7.2s vs 9.0s）
- **全段 `protocol^=http`**: これがないと yt-dlp が HLS マニフェストを返し、ffmpeg が開けません。フォールバック 3 段すべて復号を確認済み
- **timestamp を検証**: `-i` のような値を素通しすると ffmpeg が時刻ではなく**オプションとして解釈する**ため

`timestamp` は秒 / `MM:SS` / `HH:MM:SS` を受けます。`ffmpeg -ss` がそのまま解釈するのでパース処理はゼロ行で、`include_timestamps=true` の出力にある `[20:14]` をそのまま渡せます。

## issue #9 の提案のうち却下したもの

| 提案 | 却下理由 |
| --- | --- |
| キャッシュ | リモートシークにより**キャッシュ対象そのものが消滅**。フレームのキーは (動画, 秒) で長尺なら約 7,000 通り、ヒット率は約 0。しかも 1 件 123KB は文字起こし 1 本(246KB)の半分で、**読まれないエントリだけが溜まる** |
| シーン変化検出 | 投機的。「字幕が足りない箇所」は字幕を読めば判断できる |
| 別 MCP サーバーへの分離 | 「動画 1 本 = 1 情報源」。既存サーバーに 1 ツール足すだけ |

**文字起こしキャッシュは前例になりません。** あれは「動画 1 本につきキー 1 つ = 高い再利用率」と「youtube-transcript-api が IP ブロックされた際の保険」の 2 本足で立っています。フレームキャッシュはどちらも得られません。

なお、フレーム取得 7.9 秒のうち yt-dlp の URL 解決 2.3 秒だけは、キーが動画 1 本につき 1 つで文字起こしと同じ経済性を持ちます。**もし** 1 動画から複数フレームを取る使い方が観測されたら、キャッシュすべきはフレームではなくその URL で、置き場所はディスクではなくメモリ（`expire` まで）です。観測されるまでは入れません。

## 検証

- `uv run poe check` 緑（format / lint / mypy）
- `uv run python -m unittest discover -s tests` 26 件通過
- MCP 経由で実際に呼び出し、720p のフレームが返ることを確認（本 PR のブランチで動作中）

## レビュー時の注意

`structured_output=False` を指定しています。`Image` は pydantic スキーマを持たず、既存ツールと同じくエラーを文字列で返す `Image | str` の出力スキーマを生成できないためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)