### PR TITLE
Make the frame tool description trigger on on-screen content

### DIFF
--- a/server.py
+++ b/server.py
@@ -653,7 +653,8 @@ async def youtube_get_video_info(url: str) -> str:
     description=(
         "Return one video frame at a timestamp as an image. "
         "timestamp accepts seconds or MM:SS / HH:MM:SS. "
-        "Use when the transcript alone is not enough (slides, code, charts)."
+        "Slides/code/charts aren't in the transcript: grab a frame when it "
+        "references on-screen content, or when asked to capture what's shown."
     ),
     annotations=ToolAnnotations(
         title="Get YouTube Frame",


### PR DESCRIPTION
## What

Reword the `youtube_get_frame` tool description only. `youtube_get_transcript` and `youtube_get_video_info` are unchanged.

Before:
> Use when the transcript alone is not enough (slides, code, charts).

After:
> Slides/code/charts aren't in the transcript: grab a frame when it references on-screen content, or when asked to capture what's shown.

## Why

The old wording was a passive condition — "when the transcript alone is not enough" — judged by the model's own confidence. Since the model can write a plausible summary from the transcript alone, it concluded frames were never needed, so it skipped them even for slide/code-heavy talks.

Verified on a real case (AI Engineer talk `3ySF0I5iE_0`): the transcript says "Cypher query on top, SQL below" but reproduces none of the code. A frame pulled at 7:12 shows the actual Cypher/SQL, a slide subtitle ("get a subgraph back"), and concrete node names — all absent from the transcript. So slide content is genuinely missing, yet the passive trigger never fired.

The new wording moves the trigger from "is the transcript enough" (model confidence) to "does the transcript reference on-screen content" (a signal detectable from the transcript itself), plus an explicit "asked to capture what's shown" path. Stays short, since the description is copied into the client's context on tool discovery.

## Reviewer notes

- Behavior/logic unchanged; description string only.
- `ruff check` passes; module imports and the FastMCP-registered description matches the new text.
- A skill to carry the fuller slide-reconstruction workflow was considered and deliberately deferred — this one-line change works across all MCP clients, whereas a skill would only help in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)