### PR TITLE
Surface video chapters in the transcript output

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,17 @@ MCP クライアントで YouTube URL を含む依頼をします。
 - Duration: 12m30s
 - Transcript file: /abs/path/.transcript_cache/xxxxx.md
 
+## Chapters
+
+- [00:00] イントロ
+- [01:07] 本編
+
 ## Transcript
 
 こんにちは、今日は...
 ```
+
+`## Chapters` は動画にチャプターが設定されているときだけ出ます。
 
 `Transcript file` はタイムスタンプ付き全文（`[MM:SS] テキスト`）を書き出した `.md` の絶対パスです。stdio 接続でクライアントとサーバーが同一マシンにいる前提で、続きの確認・特定語の検索・区間の抜き出しは、このファイルに対してクライアント側の `Read` / `Grep` を使えば専用ツールなしで完結します（`Grep` の結果に `[MM:SS]` が含まれるので、そのまま `youtube_get_frame` の `timestamp` に渡せます）。
 
@@ -158,9 +165,13 @@ MCP クライアントで YouTube URL を含む依頼をします。
   "upload_date": "20250115",
   "duration_seconds": 750,
   "description": "動画の説明文...",
+  "chapters": [{ "start_time": 0, "end_time": 67, "title": "イントロ" }],
   "view_count": 12345
 }
 ```
+
+`chapters` はチャプター未設定の動画では `[]` です。`start_time` は秒なので、`youtube_get_frame`
+の `timestamp` にそのまま渡せます。
 
 `yt-dlp` が使えない場合や取得に失敗した場合は、`metadata_error` に理由が入ります。
 

--- a/server.py
+++ b/server.py
@@ -696,12 +696,15 @@ async def youtube_get_frame(url: str, timestamp: str) -> list | str:
     except ValueError as e:
         return str(e)
 
-    timestamp = timestamp.strip()
+    # Accept "[MM:SS]" verbatim: that is how timestamps appear in the transcript
+    # and chapter output, so agents copy them across brackets and all.
+    given = timestamp
+    timestamp = timestamp.strip().strip("[]").strip()
     # Validated, not just parsed: an unchecked value starting with "-" would be
     # read by ffmpeg as an option rather than a timestamp.
     if not TIMESTAMP_RE.fullmatch(timestamp):
         return (
-            f"Invalid timestamp: {timestamp!r}. "
+            f"Invalid timestamp: {given!r}. "
             "Use seconds (90), MM:SS (01:30), or HH:MM:SS (00:01:30)."
         )
 

--- a/server.py
+++ b/server.py
@@ -217,9 +217,20 @@ def _get_metadata(video_id: str, *, full_description: bool = False) -> dict:
         "upload_date": data.get("upload_date", ""),
         "duration_seconds": data.get("duration"),
         "description": description,
+        # Capped like description: chapters are the only header section sized by
+        # the video, and an oversized header would crowd out the transcript.
+        "chapters": (data.get("chapters") or [])[:200],
         "view_count": data.get("view_count"),
         "video_id": video_id,
     }
+
+
+def _format_timestamp(seconds: float) -> str:
+    """Format seconds as [MM:SS], or [HH:MM:SS] past the hour mark."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    return f"[{h:02d}:{m:02d}:{s:02d}]" if h > 0 else f"[{m:02d}:{s:02d}]"
 
 
 def _format_line(entry: dict, include_timestamps: bool) -> str:
@@ -227,11 +238,7 @@ def _format_line(entry: dict, include_timestamps: bool) -> str:
     text = entry["text"].strip()
     if not include_timestamps:
         return text
-    h = int(entry["start"] // 3600)
-    m = int((entry["start"] % 3600) // 60)
-    s = int(entry["start"] % 60)
-    ts = f"[{h:02d}:{m:02d}:{s:02d}]" if h > 0 else f"[{m:02d}:{s:02d}]"
-    return f"{ts} {text}"
+    return f"{_format_timestamp(entry['start'])} {text}"
 
 
 def _format_transcript(entries: list[dict], include_timestamps: bool) -> str:
@@ -308,6 +315,20 @@ def _build_output(
             f"- Metadata error: {_markdown_metadata_value(err.get('type', 'unknown'))}"
         )
 
+    chapters_section = ""
+    if metadata.get("chapters"):
+        try:
+            chapter_lines = "\n".join(
+                f"- {_format_timestamp(float(chapter.get('start_time') or 0))} "
+                f"{_markdown_metadata_value(chapter.get('title', ''))}".rstrip()
+                for chapter in metadata["chapters"]
+            )
+            chapters_section = f"\n## Chapters\n\n{chapter_lines}\n"
+        except (AttributeError, TypeError, ValueError):
+            # A chapters payload we cannot read must not sink the transcript,
+            # which by this point is already written to disk.
+            chapters_section = ""
+
     description_section = ""
     if metadata.get("description"):
         escaped = "\n".join(
@@ -320,7 +341,7 @@ def _build_output(
     return f"""# {title}
 
 {metadata_section}
-{description_section}
+{chapters_section}{description_section}
 ## Transcript
 
 {transcript_text}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -102,6 +102,54 @@ class OutputFormattingTests(unittest.TestCase):
         self.assertIn("## Description\n\nShort description", output)
         self.assertIn("## Transcript\n\nTranscript body", output)
 
+    def test_build_output_lists_chapters_when_present(self):
+        metadata = {
+            "title": "Title",
+            "author": "Author",
+            "chapters": [
+                {"start_time": 0, "end_time": 67, "title": "Introduction"},
+                {"start_time": 67, "end_time": 162, "title": "Series\npreview"},
+                {"start_time": 3725, "end_time": 3800, "title": "Wrap up"},
+            ],
+        }
+
+        output = server._build_output(
+            metadata, "Transcript body", {"language": "en"}, "dQw4w9WgXcQ"
+        )
+
+        self.assertIn(
+            "## Chapters\n\n"
+            "- [00:00] Introduction\n"
+            "- [01:07] Series preview\n"
+            "- [01:02:05] Wrap up\n",
+            output,
+        )
+        self.assertLess(output.index("## Chapters"), output.index("## Transcript"))
+
+    def test_build_output_drops_chapters_it_cannot_read(self):
+        metadata = {
+            "title": "Title",
+            "author": "Author",
+            "chapters": [{"start_time": "not a number", "title": "Broken"}],
+        }
+
+        output = server._build_output(
+            metadata, "Transcript body", {"language": "en"}, "dQw4w9WgXcQ"
+        )
+
+        self.assertNotIn("## Chapters", output)
+        self.assertIn("## Transcript\n\nTranscript body", output)
+
+    def test_build_output_omits_chapters_section_when_absent(self):
+        output = server._build_output(
+            {"title": "Title", "author": "Author", "chapters": []},
+            "Transcript body",
+            {"language": "en"},
+            "dQw4w9WgXcQ",
+        )
+
+        self.assertNotIn("## Chapters", output)
+
     def test_build_limited_output_truncates_on_entry_boundary(self):
         metadata = {"title": "Title", "author": "Author"}
         transcript_info = {"language": "en", "source": "manual"}
@@ -311,6 +359,7 @@ class MetadataTests(unittest.TestCase):
                     "upload_date": "20240501",
                     "duration": 123,
                     "description": "x" * 600,
+                    "chapters": [{"start_time": 0, "title": "Intro"}],
                     "view_count": 42,
                 }
             ),
@@ -328,6 +377,7 @@ class MetadataTests(unittest.TestCase):
         self.assertEqual(metadata["upload_date"], "20240501")
         self.assertEqual(metadata["duration_seconds"], 123)
         self.assertEqual(len(metadata["description"]), 500)
+        self.assertEqual(metadata["chapters"], [{"start_time": 0, "title": "Intro"}])
         self.assertEqual(metadata["view_count"], 42)
         self.assertEqual(metadata["video_id"], "dQw4w9WgXcQ")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -529,12 +529,27 @@ class FrameTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(extract.call_count, 1)  # second call hit the disk cache
 
     async def test_rejects_timestamp_that_ffmpeg_would_read_as_an_option(self):
-        with patch.object(server, "_extract_frame") as extract:
-            result = await server.youtube_get_frame("dQw4w9WgXcQ", "-i")
+        # "[-i]" guards the bracket-stripping path specifically: stripping must
+        # not smuggle an ffmpeg option past the validation that follows it.
+        for hostile in ("-i", "[-i]", "[01:07] -y"):
+            with self.subTest(timestamp=hostile):
+                with patch.object(server, "_extract_frame") as extract:
+                    result = await server.youtube_get_frame("dQw4w9WgXcQ", hostile)
 
-        self.assertIsInstance(result, str)
-        self.assertIn("Invalid timestamp", result)
-        extract.assert_not_called()
+                self.assertIsInstance(result, str)
+                self.assertIn("Invalid timestamp", result)
+                extract.assert_not_called()
+
+    async def test_accepts_bracketed_timestamp_copied_from_transcript_output(self):
+        with (
+            patch.object(server, "_stream_url", return_value="https://example/v.mp4"),
+            patch.object(
+                server, "_extract_frame", return_value=b"jpegbytes"
+            ) as extract,
+        ):
+            await server.youtube_get_frame("dQw4w9WgXcQ", "[01:07]")
+
+        extract.assert_called_once_with("https://example/v.mp4", "01:07")
 
     async def test_reports_extraction_failure_as_text(self):
         with (


### PR DESCRIPTION
Closes #17 ① （②の概要欄500文字カットは未着手。issue が「実装時に決める」と留保している判断待ち）

## ① チャプター

`yt-dlp --dump-json` は既に叩いていて、`chapters` は構造化フィールドでそのレスポンスに入っている。追加のネットワークコストはゼロ、新しい MCP ツールも無し。

```markdown
## Chapters

- [00:00] Introduction example
- [01:07] Series preview
- [01:02:05] Wrap up
```

`_format_timestamp` を `_format_line` から切り出してチャプター行と transcript 行で共有。これが「どちらのセクションから拾った `[MM:SS]` でも `youtube_get_frame` に渡せる」を成立させている部分。

チャプタータイトルは投稿者が自由に書ける untrusted input なので2点ガード:

- **200件でキャップ** — ヘッダで唯一動画サイズ依存のセクション。レビューで 2000 チャプターを流したところ `_build_limited_output` の最終クランプが効き、**transcript 本文も打ち切り注記も無言で消えた**。現実には description からパースされるので到達しないが、description と同じ扱いに揃えた。
- **読めないペイロードはセクションごと捨てる** — `start_time` が文字列で来ると `TypeError` で `youtube_get_transcript` ごと落ちていた。この時点で transcript は既にディスクに書き出し済みなので、装飾セクションのために本体を失うのは割に合わない。

`youtube_get_video_info` の JSON にも `chapters` が乗る（`_get_metadata` を共有しているため）。剥がさず README に明記した。

## ② `youtube_get_frame` の括弧受理（別コミット・既存バグ）

①の README を書いていて気づいた別件。README は「Grep で出た `[MM:SS]` をそのまま `youtube_get_frame` に渡せる」と書いていたが、`TIMESTAMP_RE` は数字と `:` と `.` しか通さないので**その呼び出しは全部弾かれていた**。ドキュメントが意図した動線を、コードが一度も許可していなかった。

regex を緩めるのではなく検証前に括弧を strip。`-` 始まりの値が ffmpeg にオプションとして読まれるのを防ぐという regex の役割はそのまま、strip 後の値だけがゲートに届くので `[-i]` は今も拒否される。正規化を検証前に置いたことで `_frame_path` も一形態しか見ず、`[01:07]` と `01:07` がキャッシュを分けない。

## 検証

- 32 tests / ruff / ruff format green
- 実動画 `aircAruvnKk` で 12 チャプター取得（issue の検証値と一致）
- `oh-my-claudecode:code-reviewer` によるレビュー通過（critical/major ゼロ）。指摘の minor 2件と nit 3件は本 PR に反映済み。特に「既存の `-i` テストは括弧修正**前から**通っていたので今回入れたリスクを一切カバーしていない」の指摘を受け、`[-i]` / `[01:07] -y` をテストに追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)