### PR TITLE
Keep the whole video description

### DIFF
--- a/server.py
+++ b/server.py
@@ -147,7 +147,7 @@ def _metadata_error_response(video_id: str, metadata_error: dict) -> dict:
     }
 
 
-def _get_metadata(video_id: str, *, full_description: bool = False) -> dict:
+def _get_metadata(video_id: str) -> dict:
     """Fetch video metadata using yt-dlp --dump-json."""
     url = f"https://www.youtube.com/watch?v={video_id}"
 
@@ -207,16 +207,13 @@ def _get_metadata(video_id: str, *, full_description: bool = False) -> dict:
             },
         )
 
-    description = data.get("description", "") or ""
-    if not full_description:
-        description = description[:500]
     return {
         "title": data.get("title", "Unknown"),
         "author": data.get("uploader") or data.get("channel") or "Unknown",
         "channel_url": data.get("channel_url", ""),
         "upload_date": data.get("upload_date", ""),
         "duration_seconds": data.get("duration"),
-        "description": description,
+        "description": data.get("description", "") or "",
         # Capped like description: chapters are the only header section sized by
         # the video, and an oversized header would crowd out the transcript.
         "chapters": (data.get("chapters") or [])[:200],
@@ -664,7 +661,7 @@ async def youtube_get_video_info(url: str) -> str:
         video_id = _extract_video_id(url)
     except ValueError as e:
         return str(e)
-    metadata = _get_metadata(video_id, full_description=True)
+    metadata = _get_metadata(video_id)
     return json.dumps(metadata, ensure_ascii=False, indent=2)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -348,7 +348,7 @@ class MetadataTests(unittest.TestCase):
         self.assertEqual(metadata["video_id"], "dQw4w9WgXcQ")
         self.assertEqual(metadata["metadata_error"]["type"], "yt_dlp_not_found")
 
-    def test_get_metadata_uses_ytdlp_json_and_truncates_description_by_default(self):
+    def test_get_metadata_uses_ytdlp_json_and_keeps_the_whole_description(self):
         completed = self.completed(
             stdout=json.dumps(
                 {
@@ -358,7 +358,9 @@ class MetadataTests(unittest.TestCase):
                     "channel_url": "https://youtube.com/@channel",
                     "upload_date": "20240501",
                     "duration": 123,
-                    "description": "x" * 600,
+                    # Longer than the 500-char cut this used to be subject to,
+                    # and longer than YouTube's own 5000-char description limit.
+                    "description": "x" * 6000,
                     "chapters": [{"start_time": 0, "title": "Intro"}],
                     "view_count": 42,
                 }
@@ -376,7 +378,7 @@ class MetadataTests(unittest.TestCase):
         self.assertEqual(metadata["channel_url"], "https://youtube.com/@channel")
         self.assertEqual(metadata["upload_date"], "20240501")
         self.assertEqual(metadata["duration_seconds"], 123)
-        self.assertEqual(len(metadata["description"]), 500)
+        self.assertEqual(len(metadata["description"]), 6000)
         self.assertEqual(metadata["chapters"], [{"start_time": 0, "title": "Intro"}])
         self.assertEqual(metadata["view_count"], 42)
         self.assertEqual(metadata["video_id"], "dQw4w9WgXcQ")


### PR DESCRIPTION
Closes #17 （① チャプターは #21 でマージ済み。これで ② が片付き issue は閉じられる）

## 判断

issue が「(a)/(b)/(c) を実装時に決める」と留保していたやつ。**(a) 全文を inline** を選択。

根拠を勘ではなく実測で出しました。視聴履歴535本のうち10分以上の227本から均等サンプリングした30本:

| 統計 | 値 |
|---|---|
| median | 595 |
| p75 | 1,432 |
| p90 | 2,074 |
| p95 | 2,703 |
| max | **3,864** |

| しきい値 | 該当 | 切り捨て総量 |
|---|---|---|
| **500（現状）** | **18/30 (60%)** | **15,563文字** |
| 2000（案b） | 3/30 (10%) | 2,641文字 |
| 5000（YouTube上限） | 0/30 (0%) | 0 |

- 500 カットは**6割の動画で発動**し、15,563文字を捨てている
- 対して守っている量は上限でも小さい。実測最大 3,864 文字は `MAX_TRANSCRIPT_CHARS` の **1.9%**。YouTube の概要欄上限が 5,000 文字なので、**存在しうる最悪ケースでも予算の 2.5%**
- 案(b) の 2000 も検討した。p90=2,074 がすぐ上にあるので実際に10%の動画で効くが、節約できるのは最大 2,641 文字。その代わりに「なぜ 2000 か」を説明し続ける定数が増える

## 差分

`full_description` は分岐が1つだけ残る状態になったのでパラメータごと削除。**純減の diff**（+8 / -9）。

## 検証

- 32 tests / ruff / ruff format / mypy すべて green
- 実測で最長だった動画（概要欄 3,864 文字・チャプター12件）で end-to-end 確認。出力側 3,865 文字は `#` 始まりの1行に既存の Markdown エスケープ `\` が付いた分で、全文が round-trip 一致

計測の生データと集計は手元の `experiments/desc-survey/`（gitignore 対象）にあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)